### PR TITLE
Fix for indexed-color pngs

### DIFF
--- a/ios/RCTConvert+ARKit.m
+++ b/ios/RCTConvert+ARKit.m
@@ -309,7 +309,21 @@
     
     if (property[@"path"]) {
         SCNMatrix4 m = SCNMatrix4Identity;
-        material.contents = property[@"path"];
+        
+        // scenekit has an issue with indexed-colour png's on some devices, so we redraw the image. See for more details: https://stackoverflow.com/questions/40058359/scenekit-some-textures-have-a-red-hue/45824190#45824190
+        
+        UIImage *img;
+        UIImage *texture = [UIImage imageNamed:property[@"path"]];
+        CGFloat width  = texture.size.width;
+        CGFloat height = texture.size.height;
+        
+        UIGraphicsBeginImageContext(texture.size);
+        [texture drawInRect:(CGRectMake(0, 0, width, height))];
+        img = UIGraphicsGetImageFromCurrentImageContext();
+        UIGraphicsEndImageContext();
+        
+        material.contents = img;
+
         
         if (property[@"wrapS"]) {
             material.wrapS = (SCNWrapMode) [property[@"wrapS"] integerValue];

--- a/ios/RCTConvert+ARKit.m
+++ b/ios/RCTConvert+ARKit.m
@@ -312,17 +312,17 @@
         
         // scenekit has an issue with indexed-colour png's on some devices, so we redraw the image. See for more details: https://stackoverflow.com/questions/40058359/scenekit-some-textures-have-a-red-hue/45824190#45824190
         
-        UIImage *img;
-        UIImage *texture = [UIImage imageNamed:property[@"path"]];
-        CGFloat width  = texture.size.width;
-        CGFloat height = texture.size.height;
+        UIImage *correctedImage;
+        UIImage *inputImage = [UIImage imageNamed:property[@"path"]];
+        CGFloat width  = inputImage.size.width;
+        CGFloat height = inputImage.size.height;
         
-        UIGraphicsBeginImageContext(texture.size);
-        [texture drawInRect:(CGRectMake(0, 0, width, height))];
-        img = UIGraphicsGetImageFromCurrentImageContext();
+        UIGraphicsBeginImageContext(inputImage.size);
+        [inputImage drawInRect:(CGRectMake(0, 0, width, height))];
+        correctedImage = UIGraphicsGetImageFromCurrentImageContext();
         UIGraphicsEndImageContext();
         
-        material.contents = img;
+        material.contents = correctedImage;
 
         
         if (property[@"wrapS"]) {


### PR DESCRIPTION
SceneKit has an issue with indexed-colour png's on some devices, as a work-around we redraw the image. See for more details: https://stackoverflow.com/questions/40058359/scenekit-some-textures-have-a-red-hue/45824190#45824190

Before: 
![img_0164](https://user-images.githubusercontent.com/1694288/37293947-05a44a64-2615-11e8-8d55-ba83bc3f99fa.JPG)

Wallpaper should be white, renders in simulator as white, but in iphone x it's red.

After: 

![img_0039](https://user-images.githubusercontent.com/1694288/37294046-471d29f2-2615-11e8-9b98-fec713942285.PNG)



