### PR TITLE
Push sprite offscreen if it's behind the camera

### DIFF
--- a/ios/components/RCTARKitSpriteView.m
+++ b/ios/components/RCTARKitSpriteView.m
@@ -22,7 +22,11 @@
 
 - (CGAffineTransform)getTransform {
     SCNVector3 point = [[ARKit sharedInstance] projectPoint:self.position3D];
-    CGAffineTransform t = CGAffineTransformMakeTranslation(point.x, point.y);
+    
+    // the sprite is behind the camera so push it off screen
+    float yTransform = point.z < 1 ? point.y : 1000;
+    
+    CGAffineTransform t = CGAffineTransformMakeTranslation(point.x, yTransform);
     return t;
 }
 
@@ -40,7 +44,6 @@
 - (void)setTransformByProject {
     CGAffineTransform t = [self getTransform];
     [UIView beginAnimations:nil context:NULL];
-    
     [UIView setAnimationDuration:self.transitionDuration];
     [self setTransform:t];
     [UIView commitAnimations];

--- a/ios/components/RCTARKitSpriteView.m
+++ b/ios/components/RCTARKitSpriteView.m
@@ -24,7 +24,7 @@
     SCNVector3 point = [[ARKit sharedInstance] projectPoint:self.position3D];
     
     // the sprite is behind the camera so push it off screen
-    float yTransform = point.z < 1 ? point.y : 1000;
+    float yTransform = point.z < 1 ? point.y : 10000;
     
     CGAffineTransform t = CGAffineTransformMakeTranslation(point.x, yTransform);
     return t;


### PR DESCRIPTION
This is a quick fix for the problem that sprites behind the camera are still visible. 

Reference for projectPoint: https://developer.apple.com/documentation/scenekit/scnscenerenderer/1524089-projectpoint?language=objc

More than happy to try again with suggestions.