### PR TITLE
WIP: Hopefully fix crash pt. 2

### DIFF
--- a/ios/RCTARKitNodes.m
+++ b/ios/RCTARKitNodes.m
@@ -329,8 +329,9 @@ static id ObjectOrNull(id object)
 - (void)removeNode:(NSString *)nodeId {
     
     SCNNode *node = [self getNodeWithId:nodeId];
+
     if (node) {
-        //NSLog(@"removing node: %@ ", key);
+//        NSLog(@"removing node: %@ ", node);
      
         if(node.parentNode) {
             if(node.light) {
@@ -343,7 +344,12 @@ static id ObjectOrNull(id object)
                 return;
             }
         }
-        [self.nodes removeObjectForKey:nodeId];
+        @try {
+            [self.nodes removeObjectForKey:nodeId];
+        }
+        @catch (NSException *err) {
+            NSLog(@"Error... %@", [err callStackSymbols]);
+        }
     }
 }
 

--- a/ios/RCTARKitNodes.m
+++ b/ios/RCTARKitNodes.m
@@ -337,8 +337,10 @@ static id ObjectOrNull(id object)
                 // see https://stackoverflow.com/questions/47270056/how-to-remove-a-light-with-shadowmode-deferred-in-scenekit-arkit?noredirect=1#comment81491270_47270056
                 node.hidden = YES;
                 [node removeFromParentNode];
+                return;
             } else {
                 [node removeFromParentNode];
+                return;
             }
         }
         [self.nodes removeObjectForKey:nodeId];


### PR DESCRIPTION
Seeing a lot of crashes come from here: https://github.com/react-native-ar/react-native-arkit/blob/master/ios/RCTARKitNodes.m#L344, maybe it helps to return early from this method.

Edit: Actually I think I misunderstood what `[node removeFromParentNode];` is doing. First assumption was that objc deallocates unattached nodes so that `[self.nodes removeObjectForKey:nodeId];` wouldn't be necessary after removing it from the parent.
https://developer.apple.com/documentation/scenekit/scnnode/1407991-removefromparentnode?language=objc