### PR TITLE
Undo texture channel fix

### DIFF
--- a/ios/RCTConvert+ARKit.m
+++ b/ios/RCTConvert+ARKit.m
@@ -310,19 +310,8 @@
     if (property[@"path"]) {
         SCNMatrix4 m = SCNMatrix4Identity;
         
-        // scenekit has an issue with indexed-colour png's on some devices, so we redraw the image. See for more details: https://stackoverflow.com/questions/40058359/scenekit-some-textures-have-a-red-hue/45824190#45824190
-        
-        UIImage *correctedImage;
-        UIImage *inputImage = [UIImage imageNamed:property[@"path"]];
-        CGFloat width  = inputImage.size.width;
-        CGFloat height = inputImage.size.height;
-        
-        UIGraphicsBeginImageContext(inputImage.size);
-        [inputImage drawInRect:(CGRectMake(0, 0, width, height))];
-        correctedImage = UIGraphicsGetImageFromCurrentImageContext();
-        UIGraphicsEndImageContext();
-        
-        material.contents = correctedImage;
+        // scenekit has an issue with indexed-colour png's on some devices, See for more details: https://stackoverflow.com/questions/40058359/scenekit-some-textures-have-a-red-hue/45824190#45824190 to fix this we could re-implement https://github.com/react-native-ar/react-native-arkit/pull/171 in a more performant way
+        material.contents = property[@"path"];
 
         
         if (property[@"wrapS"]) {

--- a/ios/RCTConvert+ARKit.m
+++ b/ios/RCTConvert+ARKit.m
@@ -309,7 +309,21 @@
     
     if (property[@"path"]) {
         SCNMatrix4 m = SCNMatrix4Identity;
-        material.contents = property[@"path"];
+        
+        // scenekit has an issue with indexed-colour png's on some devices, so we redraw the image. See for more details: https://stackoverflow.com/questions/40058359/scenekit-some-textures-have-a-red-hue/45824190#45824190
+        
+        UIImage *img;
+        UIImage *texture = [UIImage imageNamed:property[@"path"]];
+        CGFloat width  = texture.size.width;
+        CGFloat height = texture.size.height;
+        
+        UIGraphicsBeginImageContext(texture.size);
+        [texture drawInRect:(CGRectMake(0, 0, width, height))];
+        img = UIGraphicsGetImageFromCurrentImageContext();
+        UIGraphicsEndImageContext();
+        
+        material.contents = img;
+
         
         if (property[@"wrapS"]) {
             material.wrapS = (SCNWrapMode) [property[@"wrapS"] integerValue];

--- a/ios/RCTConvert+ARKit.m
+++ b/ios/RCTConvert+ARKit.m
@@ -312,17 +312,17 @@
         
         // scenekit has an issue with indexed-colour png's on some devices, so we redraw the image. See for more details: https://stackoverflow.com/questions/40058359/scenekit-some-textures-have-a-red-hue/45824190#45824190
         
-        UIImage *img;
-        UIImage *texture = [UIImage imageNamed:property[@"path"]];
-        CGFloat width  = texture.size.width;
-        CGFloat height = texture.size.height;
+        UIImage *correctedImage;
+        UIImage *inputImage = [UIImage imageNamed:property[@"path"]];
+        CGFloat width  = inputImage.size.width;
+        CGFloat height = inputImage.size.height;
         
-        UIGraphicsBeginImageContext(texture.size);
-        [texture drawInRect:(CGRectMake(0, 0, width, height))];
-        img = UIGraphicsGetImageFromCurrentImageContext();
+        UIGraphicsBeginImageContext(inputImage.size);
+        [inputImage drawInRect:(CGRectMake(0, 0, width, height))];
+        correctedImage = UIGraphicsGetImageFromCurrentImageContext();
         UIGraphicsEndImageContext();
         
-        material.contents = img;
+        material.contents = correctedImage;
 
         
         if (property[@"wrapS"]) {

--- a/ios/components/RCTARKitSpriteView.m
+++ b/ios/components/RCTARKitSpriteView.m
@@ -22,7 +22,11 @@
 
 - (CGAffineTransform)getTransform {
     SCNVector3 point = [[ARKit sharedInstance] projectPoint:self.position3D];
-    CGAffineTransform t = CGAffineTransformMakeTranslation(point.x, point.y);
+    
+    // the sprite is behind the camera so push it off screen
+    float yTransform = point.z < 1 ? point.y : 1000;
+    
+    CGAffineTransform t = CGAffineTransformMakeTranslation(point.x, yTransform);
     return t;
 }
 
@@ -40,7 +44,6 @@
 - (void)setTransformByProject {
     CGAffineTransform t = [self getTransform];
     [UIView beginAnimations:nil context:NULL];
-    
     [UIView setAnimationDuration:self.transitionDuration];
     [self setTransform:t];
     [UIView commitAnimations];

--- a/ios/components/RCTARKitSpriteView.m
+++ b/ios/components/RCTARKitSpriteView.m
@@ -24,7 +24,7 @@
     SCNVector3 point = [[ARKit sharedInstance] projectPoint:self.position3D];
     
     // the sprite is behind the camera so push it off screen
-    float yTransform = point.z < 1 ? point.y : 1000;
+    float yTransform = point.z < 1 ? point.y : 10000;
     
     CGAffineTransform t = CGAffineTransformMakeTranslation(point.x, yTransform);
     return t;


### PR DESCRIPTION
The texture channel fix from https://github.com/react-native-ar/react-native-arkit/pull/171 works but turns out to be very memory intensive, in some cases leading to crashes. I suggest we undo it until it can be implemented in a more performant way. Either by caching textures or introducing a `ARKit.createTexture` helper to register textures. 