### PR TITLE
add basic phycis support for primitives

### DIFF
--- a/components/lib/createArComponent.js
+++ b/components/lib/createArComponent.js
@@ -11,15 +11,16 @@ import some from 'lodash/some';
 import {
   castsShadow,
   categoryBitMask,
+  constraint,
   eulerAngles,
   opacity,
   orientation,
+  physicsBody,
   position,
   renderingOrder,
   rotation,
   scale,
-  constraint,
-  transition,
+  transition
 } from './propTypes';
 import addAnimatedSupport from './addAnimatedSupport';
 import generateId from './generateId';
@@ -31,11 +32,11 @@ const { ARGeosManager } = NativeModules;
 
 const PROP_TYPES_IMMUTABLE = {
   id: PropTypes.string,
-  frame: PropTypes.string,
+  frame: PropTypes.string
 };
 const MOUNT_UNMOUNT_ANIMATION_PROPS = {
   propsOnMount: PropTypes.any,
-  propsOnUnMount: PropTypes.any,
+  propsOnUnMount: PropTypes.any
 };
 const PROP_TYPES_NODE = {
   position,
@@ -49,6 +50,7 @@ const PROP_TYPES_NODE = {
   renderingOrder,
   opacity,
   constraint,
+  physicsBody
 };
 
 const NODE_PROPS = keys(PROP_TYPES_NODE);
@@ -69,7 +71,7 @@ export default (mountConfig, propTypes = {}, nonUpdateablePropKeys = []) => {
     ...MOUNT_UNMOUNT_ANIMATION_PROPS,
     ...PROP_TYPES_IMMUTABLE,
     ...PROP_TYPES_NODE,
-    ...propTypes,
+    ...propTypes
   };
   // any custom props (material, shape, ...)
   const nonNodePropKeys = keys(propTypes);
@@ -80,7 +82,7 @@ export default (mountConfig, propTypes = {}, nonUpdateablePropKeys = []) => {
       ? { shadowColor: processColor(props.shadowColor) }
       : {}),
     ...(props.color ? { color: processColor(props.color) } : {}),
-    ...(props.material ? { material: processMaterial(props.material) } : {}),
+    ...(props.material ? { material: processMaterial(props.material) } : {})
   });
 
   const getNonNodeProps = props => parseMaterials(pick(props, nonNodePropKeys));
@@ -96,10 +98,10 @@ export default (mountConfig, propTypes = {}, nonUpdateablePropKeys = []) => {
       getNonNodeProps(props),
       {
         id,
-        ...pick(props, NODE_PROPS),
+        ...pick(props, NODE_PROPS)
       },
       props.frame,
-      parentId,
+      parentId
     );
   };
 
@@ -124,7 +126,7 @@ export default (mountConfig, propTypes = {}, nonUpdateablePropKeys = []) => {
       if (propsOnMount) {
         const fullPropsOnMount = { ...props, ...propsOnMount };
         const {
-          transition: transitionOnMount = { duration: 0 },
+          transition: transitionOnMount = { duration: 0 }
         } = fullPropsOnMount;
 
         this.doPendingTimers();
@@ -144,7 +146,7 @@ export default (mountConfig, propTypes = {}, nonUpdateablePropKeys = []) => {
     componentWillUpdate(props) {
       const changedKeys = filter(
         keys(this.props),
-        key => key !== 'children' && !isDeepEqual(props[key], this.props[key]),
+        key => key !== 'children' && !isDeepEqual(props[key], this.props[key])
       );
       if (isEmpty(changedKeys)) {
         return;
@@ -152,14 +154,14 @@ export default (mountConfig, propTypes = {}, nonUpdateablePropKeys = []) => {
 
       if (__DEV__) {
         const nonAllowedUpdates = filter(changedKeys, k =>
-          IMMUTABLE_PROPS.includes(k),
+          IMMUTABLE_PROPS.includes(k)
         );
         if (nonAllowedUpdates.length > 0) {
           throw new Error(
             `[${this
               .identifier}] prop can't be updated: '${nonAllowedUpdates.join(
-              ', ',
-            )}'`,
+              ', '
+            )}'`
           );
         }
       }
@@ -168,7 +170,7 @@ export default (mountConfig, propTypes = {}, nonUpdateablePropKeys = []) => {
         if (DEBUG)
           console.log(
             `[${this.identifier}] need to remount node because of `,
-            changedKeys,
+            changedKeys
           );
         this.mountWithProps({ ...this.props, ...props });
       } else {
@@ -179,9 +181,9 @@ export default (mountConfig, propTypes = {}, nonUpdateablePropKeys = []) => {
           // always inclue transition
           transition: {
             ...this.props.transition,
-            ...props.transition,
+            ...props.transition
           },
-          ...parseMaterials(pick(props, changedKeys)),
+          ...parseMaterials(pick(props, changedKeys))
         };
         update(this.identifier, propsToupdate).catch(() => {
           // sometimes calls are out of order, so this node has been unmounted
@@ -217,7 +219,7 @@ export default (mountConfig, propTypes = {}, nonUpdateablePropKeys = []) => {
           callback.call(this);
           delete TIMERS[this.identifier];
         }, duration),
-        callback,
+        callback
       };
     }
 
@@ -232,7 +234,7 @@ export default (mountConfig, propTypes = {}, nonUpdateablePropKeys = []) => {
     }
     getChildContext() {
       return {
-        arkitParentId: this.identifier,
+        arkitParentId: this.identifier
       };
     }
 
@@ -243,10 +245,10 @@ export default (mountConfig, propTypes = {}, nonUpdateablePropKeys = []) => {
     }
   };
   ARComponent.childContextTypes = {
-    arkitParentId: PropTypes.string,
+    arkitParentId: PropTypes.string
   };
   ARComponent.contextTypes = {
-    arkitParentId: PropTypes.string,
+    arkitParentId: PropTypes.string
   };
 
   const ARComponentAnimated = addAnimatedSupport(ARComponent);

--- a/components/lib/propTypes.js
+++ b/components/lib/propTypes.js
@@ -6,90 +6,95 @@ const ARKitManager = NativeModules.ARKitManager;
 
 const animatableNumber = PropTypes.oneOfType([
   PropTypes.number,
-  PropTypes.object,
+  PropTypes.object
 ]);
 
 export const deprecated = (propType, hint = null) => (
   props,
   propName,
-  componentName,
+  componentName
 ) => {
   if (props[propName]) {
     console.warn(
       `Prop \`${propName}\` supplied to` +
-        ` \`${componentName}\` is deprecated. ${hint}`,
+        ` \`${componentName}\` is deprecated. ${hint}`
     );
   }
   return PropTypes.checkPropTypes(
     { [propName]: propType },
     props,
     propName,
-    componentName,
+    componentName
   );
 };
 export const position = PropTypes.shape({
   x: animatableNumber,
   y: animatableNumber,
-  z: animatableNumber,
+  z: animatableNumber
 });
 
 export const scale = animatableNumber;
 export const categoryBitMask = PropTypes.number;
 export const transition = PropTypes.shape({
-  duration: PropTypes.number,
+  duration: PropTypes.number
 });
 
 export const planeDetection = PropTypes.oneOf(
-  values(ARKitManager.ARPlaneDetection),
+  values(ARKitManager.ARPlaneDetection)
 );
 export const eulerAngles = PropTypes.shape({
   x: animatableNumber,
   y: animatableNumber,
-  z: animatableNumber,
+  z: animatableNumber
 });
 
 export const rotation = PropTypes.shape({
   x: animatableNumber,
   y: animatableNumber,
   z: animatableNumber,
-  w: animatableNumber,
+  w: animatableNumber
 });
 
 export const orientation = PropTypes.shape({
   x: animatableNumber,
   y: animatableNumber,
   z: animatableNumber,
-  w: animatableNumber,
+  w: animatableNumber
+});
+
+export const physicsBody = PropTypes.shape({
+  mass: PropTypes.number,
+  type: PropTypes.oneOf(values(ARKitManager.PhysicsBodyType))
 });
 
 export const textureTranslation = PropTypes.shape({
   x: PropTypes.number,
   y: PropTypes.number,
-  z: PropTypes.number,
+  z: PropTypes.number
 });
 
 export const textureRotation = PropTypes.shape({
   angle: PropTypes.number,
   x: PropTypes.number,
   y: PropTypes.number,
-  z: PropTypes.number,
+  z: PropTypes.number
 });
 
 export const textureScale = PropTypes.shape({
   x: PropTypes.number,
   y: PropTypes.number,
-  z: PropTypes.number,
+  z: PropTypes.number
 });
 
 export const shaders = PropTypes.shape({
   [ARKitManager.ShaderModifierEntryPoint.Geometry]: PropTypes.string,
   [ARKitManager.ShaderModifierEntryPoint.Surface]: PropTypes.string,
   [ARKitManager.ShaderModifierEntryPoint.LightingModel]: PropTypes.string,
-  [ARKitManager.ShaderModifierEntryPoint.Fragment]: PropTypes.string,
+  [ARKitManager.ShaderModifierEntryPoint.Fragment]: PropTypes.string
 });
 
 export const lightingModel = PropTypes.oneOf(
-  values(ARKitManager.LightingModel),
+  values(ARKitManager.LightingModel)
 );
 
 export const castsShadow = PropTypes.bool;
@@ -102,7 +107,7 @@ export const fillMode = PropTypes.oneOf(values(ARKitManager.FillMode));
 export const lightType = PropTypes.oneOf(values(ARKitManager.LightType));
 export const shadowMode = PropTypes.oneOf(values(ARKitManager.ShadowMode));
 export const colorBufferWriteMask = PropTypes.oneOf(
-  values(ARKitManager.ColorMask),
+  values(ARKitManager.ColorMask)
 );
 
 export const opacity = animatableNumber;
@@ -120,7 +125,7 @@ export const materialProperty = PropTypes.shape({
   wrap: wrapMode,
   translation: textureTranslation,
   scale: textureScale,
-  rotation: textureRotation,
+  rotation: textureRotation
 });
 
 export const material = PropTypes.shape({
@@ -139,10 +144,10 @@ export const material = PropTypes.shape({
   doubleSided: PropTypes.bool,
   litPerPixel: PropTypes.bool,
   transparency: PropTypes.number,
-  fillMode,
+  fillMode
 });
 
 const detectionImage = PropTypes.shape({
-  resourceGroupName: PropTypes.string,
+  resourceGroupName: PropTypes.string
 });
 export const detectionImages = PropTypes.arrayOf(detectionImage);

--- a/ios/RCTARKit.m
+++ b/ios/RCTARKit.m
@@ -11,7 +11,7 @@
 
 @import CoreLocation;
 
-@interface RCTARKit () <ARSCNViewDelegate, ARSessionDelegate, UIGestureRecognizerDelegate> {
+@interface RCTARKit () <ARSCNViewDelegate, ARSessionDelegate, UIGestureRecognizerDelegate, SCNPhysicsContactDelegate> {
     RCTARKitResolve _resolve;
 }
 
@@ -48,7 +48,9 @@ static RCTARKit *instance = nil;
     
     dispatch_once_on_main_thread(&onceToken, ^{
         if (instance == nil) {
+            
             ARSCNView *arView = [[ARSCNView alloc] init];
+            
             instance = [[self alloc] initWithARView:arView];
         }
     });
@@ -64,10 +66,10 @@ static RCTARKit *instance = nil;
 - (instancetype)initWithARView:(ARSCNView *)arView {
     if ((self = [super init])) {
         self.arView = arView;
-        
         // delegates
         arView.delegate = self;
         arView.session.delegate = self;
+        arView.scene.physicsWorld.contactDelegate = self;
         
         UITapGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTapFrom:)];
         tapGestureRecognizer.numberOfTapsRequired = 1;
@@ -157,7 +159,8 @@ static RCTARKit *instance = nil;
 - (void)setDebug:(BOOL)debug {
     if (debug) {
         self.arView.showsStatistics = YES;
-        self.arView.debugOptions = ARSCNDebugOptionShowWorldOrigin | ARSCNDebugOptionShowFeaturePoints;
+        
+        self.arView.debugOptions = ARSCNDebugOptionShowWorldOrigin | ARSCNDebugOptionShowFeaturePoints | SCNDebugOptionShowPhysicsShapes;
     } else {
         self.arView.showsStatistics = NO;
         self.arView.debugOptions = SCNDebugOptionNone;
@@ -572,6 +575,7 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
      NSLog(@"removed, number of renderer delegates %d", [self.rendererDelegates count]);
 }
 - (void)renderer:(id <SCNSceneRenderer>)renderer willUpdateNode:(SCNNode *)node forAnchor:(ARAnchor *)anchor {
+    
 }
 
 
@@ -736,7 +740,19 @@ static NSDictionary * getPlaneHitResult(NSMutableArray *resultsMapped, const CGP
         }
     }
 }
+#pragma mark - SCNPhysicsContactDelegate
 
+- (void)physicsWorld:(SCNPhysicsWorld *)world didBeginContact:(SCNPhysicsContact *)contact {
+    
+}
+
+- (void)physicsWorld:(SCNPhysicsWorld *)world didUpdateContact:(SCNPhysicsContact *)contact {
+    
+}
+
+- (void)physicsWorld:(SCNPhysicsWorld *)world didEndContact:(SCNPhysicsContact *)contact {
+    
+}
 
 
 #pragma mark - dealloc

--- a/ios/RCTARKitManager.m
+++ b/ios/RCTARKitManager.m
@@ -132,6 +132,11 @@ RCT_EXPORT_MODULE()
                      @"GravityAndHeading": @(ARWorldAlignmentGravityAndHeading),
                      @"Camera": @(ARWorldAlignmentCamera),
                      },
+             @"PhysicsBodyType": @{
+                     @"Static": @(SCNPhysicsBodyTypeStatic),
+                     @"Dynamic": @(SCNPhysicsBodyTypeDynamic),
+                     @"Kinematic": @(SCNPhysicsBodyTypeKinematic),
+                     },
              @"FillMode": @{
                      @"Fill": [@(SCNFillModeFill) stringValue],
                      @"Lines": [@(SCNFillModeLines) stringValue],

--- a/ios/RCTConvert+ARKit.m
+++ b/ios/RCTConvert+ARKit.m
@@ -172,6 +172,15 @@
     return geometry;
 }
 
++ (SCNPhysicsBody *)SCNPhysicsBody:(id)json {
+    SCNPhysicsBodyType type = [json[@"type"] integerValue];
+    SCNPhysicsBody* body = [SCNPhysicsBody bodyWithType:type shape:nil];
+    if(json[@"mass"]) {
+        body.mass = [json[@"mass"] floatValue];
+    }
+    return body;
+}
+
 + (SVGBezierPath *)svgStringToBezier:(NSString *)pathString {
     NSArray * paths = [SVGBezierPath pathsFromSVGString:pathString];
     SVGBezierPath * fullPath;
@@ -431,7 +440,11 @@
 }
 
 + (void)setNodeProperties:(SCNNode *)node properties:(id)json {
-    
+    if(json[@"physicsBody"]) {
+        node.physicsBody = [self SCNPhysicsBody:json[@"physicsBody"]];
+        
+        
+    }
     if (json[@"categoryBitMask"]) {
         node.categoryBitMask = [json[@"categoryBitMask"] integerValue];
     }

--- a/ios/components/ARGeosManager.m
+++ b/ios/components/ARGeosManager.m
@@ -14,74 +14,78 @@
 RCT_EXPORT_MODULE()
 
 
-RCT_EXPORT_METHOD(addBox:(SCNBox *)geometry node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject ) {
-    node.geometry = geometry;
+- (void)addNodeWithGeometry:(SCNNode *)node geometry:(SCNGeometry *)geometry frame:(NSString *)frame parentId:(NSString *)parentId {
+    if(geometry) {
+        node.geometry = geometry;
+        // usually, scenekit will use the same geometry for physicsshape,
+        // if you assign a physicsBody without a shape.
+        // but because we create SCNNode and the geometry indipendently, scenekit will know the geometry, so we add it here manually
+        if(node.physicsBody && ! node.physicsBody.physicsShape) {
+            node.physicsBody.physicsShape = [SCNPhysicsShape shapeWithGeometry:geometry options:nil];
+        }
+    }
     [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame withParentId:parentId];
+
+}
+
+RCT_EXPORT_METHOD(addBox:(SCNBox *)geometry node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject ) {
+    [self addNodeWithGeometry:node geometry:geometry frame:frame  parentId:parentId];
     resolve(nil);
 }
 
 RCT_EXPORT_METHOD(addGroup:(id)bla node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
-    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame withParentId:parentId];
+   [self addNodeWithGeometry:node geometry:nil frame:frame  parentId:parentId];
     resolve(nil);
 }
 
 RCT_EXPORT_METHOD(addSphere:(SCNSphere *)geometry node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
-    node.geometry = geometry;
-    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame withParentId:parentId];
+      [self addNodeWithGeometry:node geometry:geometry frame:frame  parentId:parentId];
     resolve(nil);
 }
 
 RCT_EXPORT_METHOD(addCylinder:(SCNCylinder *)geometry node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
-    node.geometry = geometry;
-    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame withParentId:parentId];
+  [self addNodeWithGeometry:node geometry:geometry frame:frame  parentId:parentId];
     resolve(nil);
 }
 
 RCT_EXPORT_METHOD(addCone:(SCNCone *)geometry node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
-    node.geometry = geometry;
-    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame withParentId:parentId];
+     [self addNodeWithGeometry:node geometry:geometry frame:frame  parentId:parentId];
     resolve(nil);
 }
 
 RCT_EXPORT_METHOD(addPyramid:(SCNPyramid *)geometry node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
-    node.geometry = geometry;
-    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame withParentId:parentId];
+     [self addNodeWithGeometry:node geometry:geometry frame:frame  parentId:parentId];
     resolve(nil);
 }
 
 RCT_EXPORT_METHOD(addTube:(SCNTube *)geometry node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
-    node.geometry = geometry;
-    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame withParentId:parentId];
+     [self addNodeWithGeometry:node geometry:geometry frame:frame  parentId:parentId];
     resolve(nil);
 }
 
 RCT_EXPORT_METHOD(addTorus:(SCNTorus *)geometry node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
-    node.geometry = geometry;
-    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame withParentId:parentId];
+     [self addNodeWithGeometry:node geometry:geometry frame:frame  parentId:parentId];
     resolve(nil);
 }
 
 RCT_EXPORT_METHOD(addCapsule:(SCNCapsule *)geometry node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
-    node.geometry = geometry;
-    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame withParentId:parentId];
+    [self addNodeWithGeometry:node geometry:geometry frame:frame  parentId:parentId];
     resolve(nil);
 }
 
 RCT_EXPORT_METHOD(addPlane:(SCNPlane *)geometry node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
-    node.geometry = geometry;
-    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame withParentId:parentId];
+     [self addNodeWithGeometry:node geometry:geometry frame:frame  parentId:parentId];
     resolve(nil);
 }
 
 RCT_EXPORT_METHOD(addShape:(SCNShape *)geometry node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
-    node.geometry = geometry;
-    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame withParentId:parentId];
+     [self addNodeWithGeometry:node geometry:geometry frame:frame  parentId:parentId];
     resolve(nil);
 }
 
 RCT_EXPORT_METHOD(addLight:(SCNLight *)light node:(SCNNode *)node frame:(NSString *)frame parentId:(NSString *)parentId resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
     node.light = light;
-    [[RCTARKitNodes sharedInstance] addNodeToScene:node inReferenceFrame:frame withParentId:parentId];
+     [self addNodeWithGeometry:node geometry:nil frame:frame parentId:parentId];
     resolve(nil);
 }
 


### PR DESCRIPTION
you can now add phycisbody to your 3d objects:

```
<ARKit.Sphere
      transition={{ duration: 0.1 }}
      position={{ x: 1, y: 2, z: 1 }}
      shape={{ radius: 0.1 }}
      physicsBody={{
        type: ARKit.PhysicsBodyType.Dynamic,
        mass: 1
      }}
    />
    <ARKit.Plane
      eulerAngles={{ x: Math.PI / 2 }}
      position={{ x: 0, y: 0, z: 0 }}
      physicsBody={{
        type: ARKit.PhysicsBodyType.Kinematic
      }}
  shape={{
        width: 100,
        height: 100
      }}
/>

```

this only works for primitives at the moment. i will add support for models and groups later.