### PR TITLE
Add support for emission and transparent material properties

### DIFF
--- a/ios/RCTConvert+ARKit.m
+++ b/ios/RCTConvert+ARKit.m
@@ -405,8 +405,16 @@
         [self setMaterialPropertyContents:json[@"displacement"] material:material.displacement];
     }
     
+    if (json[@"emission"]) {
+        [self setMaterialPropertyContents:json[@"emission"] material:material.emission];
+    }
+    
     if (json[@"specular"]) {
         [self setMaterialPropertyContents:json[@"specular"] material:material.specular];
+    }
+    
+    if (json[@"transparent"]) {
+        [self setMaterialPropertyContents:json[@"transparent"] material:material.transparent];
     }
     
     if (json[@"transparency"]) {


### PR DESCRIPTION
These two properties of material were not bound.  Now you can control the texture per-pixel transparency and emission from javascript.